### PR TITLE
Controller should be upper case

### DIFF
--- a/tutorials_automated_testing/OVSRyu/ryu.yml
+++ b/tutorials_automated_testing/OVSRyu/ryu.yml
@@ -96,7 +96,7 @@
     command: ovs-vsctl add-port br0 eth5
 
   - name: set controller
-    command: ovs-vsctl set-controller br0 tcp:{{ hostvars['controller']['ansible_eth0']['ipv4']['address'] }}:6633
+    command: ovs-vsctl set-controller br0 tcp:{{ hostvars['Controller']['ansible_eth0']['ipv4']['address'] }}:6633
 
   - name: set fail-mode
     command: ovs-vsctl set-fail-mode br0 secure


### PR DESCRIPTION
There was still one "Controller" that needed to be upper case, to match the RSpec client_id